### PR TITLE
ThirdDogSettingViewController 리팩토링

### DIFF
--- a/GaeManda/Projects/Core/GMDUtils/Base/BaseViewController.swift
+++ b/GaeManda/Projects/Core/GMDUtils/Base/BaseViewController.swift
@@ -14,9 +14,11 @@ import SnapKit
 open class BaseViewController: UIViewController {
 	// MARK: - Properties
 	public var disposeBag = DisposeBag()
+	public var keyboardShowNotification: NSObjectProtocol?
+	public var keyboardHideNotification: NSObjectProtocol?
 	
 	// MARK: - UI Components
-	private let scrollView: UIScrollView = {
+	public let scrollView: UIScrollView = {
 		let scrollView = UIScrollView()
 		scrollView.showsVerticalScrollIndicator = false
 		scrollView.showsHorizontalScrollIndicator = false
@@ -38,7 +40,8 @@ open class BaseViewController: UIViewController {
 	open override func viewDidLoad() {
 		super.viewDidLoad()
 		self.view.backgroundColor = .white
-		registerKeyboardNotification()
+		self.keyboardShowNotification = registerKeyboardShowNotification()
+		self.keyboardHideNotification = registerKeyboardHideNotification()
 		// bind
 		contentView.rx.tapGesture()
 			.when(.recognized)
@@ -48,8 +51,9 @@ open class BaseViewController: UIViewController {
 			.disposed(by: disposeBag)
 	}
 	
-	open override func viewDidDisappear(_ animated: Bool) {
-		removeKeyboardNotification()
+	open override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+		removeKeyboardNotification([keyboardShowNotification, keyboardHideNotification])
 	}
 	
 	// MARK: - Methods

--- a/GaeManda/Projects/Core/GMDUtils/KeyboardListener.swift
+++ b/GaeManda/Projects/Core/GMDUtils/KeyboardListener.swift
@@ -10,13 +10,17 @@ import UIKit
 import GMDExtensions
 
 public protocol KeyboardListener {
+	var keyboardShowNotification: NSObjectProtocol? { get set }
+	var keyboardHideNotification: NSObjectProtocol? { get set }
+	
 	func keyboardWillShow(height: CGFloat)
 	func keyboardWillHide()
 }
 
 public extension KeyboardListener where Self: UIViewController {
-	func registerKeyboardNotification() {
-		NotificationCenter.default.addObserver(
+	@discardableResult
+	func registerKeyboardShowNotification() -> NSObjectProtocol? {
+		let showNotification = NotificationCenter.default.addObserver(
 			forName: UIResponder.keyboardWillShowNotification,
 			object: nil,
 			queue: nil
@@ -24,18 +28,22 @@ public extension KeyboardListener where Self: UIViewController {
 			guard let height = notification.keyboardHeight else { return }
 			self?.keyboardWillShow(height: height)
 		}
-		
-		NotificationCenter.default.addObserver(
+		return showNotification
+	}
+	
+	@discardableResult
+	func registerKeyboardHideNotification() -> NSObjectProtocol? {
+		let hideNotification = NotificationCenter.default.addObserver(
 			forName: UIResponder.keyboardWillHideNotification,
 			object: nil,
 			queue: nil
 		) { [weak self] _ in
 			self?.keyboardWillHide()
 		}
+		return hideNotification
 	}
 	
-	func removeKeyboardNotification() {
-		NotificationCenter.default.removeObserver(UIResponder.keyboardWillShowNotification)
-		NotificationCenter.default.removeObserver(UIResponder.keyboardWillHideNotification)
+	func removeKeyboardNotification(_ notifications: [NSObjectProtocol?]) {
+		notifications.forEach(NotificationCenter.default.removeObserver(_:))
 	}
 }

--- a/GaeManda/Projects/Domain/Entity/Dog.swift
+++ b/GaeManda/Projects/Domain/Entity/Dog.swift
@@ -13,6 +13,11 @@ public enum Sex: String {
 	case female = "여"
 }
 
+public enum Neutered {
+	case `true`
+	case `false`
+}
+
 public struct Dog {
 	public let name: String
 	public let sex: String

--- a/GaeManda/Projects/Presentation/Chatting/Implementations/Chatting/ChattingViewController.swift
+++ b/GaeManda/Projects/Presentation/Chatting/Implementations/Chatting/ChattingViewController.swift
@@ -27,6 +27,8 @@ final class ChattingViewController:
 	ChattingViewControllable {
 	weak var listener: ChattingPresentableListener?
 	private let disposeBag = DisposeBag()
+	var keyboardShowNotification: NSObjectProtocol?
+	var keyboardHideNotification: NSObjectProtocol?
 	
 	// MARK: - UI Components
 	private lazy var navigationBar = GMDNavigationBar(
@@ -67,10 +69,11 @@ final class ChattingViewController:
 	// MARK: - Life Cycle
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		self.keyboardShowNotification = registerKeyboardShowNotification()
+		self.keyboardHideNotification = registerKeyboardHideNotification()
 		view.backgroundColor = .gray20
 		navigationBar.titleLabel.font = .r16
 		setupUI()
-		registerKeyboardNotification()
 	}
 	
 	override func viewWillAppear(_ animated: Bool) {
@@ -80,7 +83,7 @@ final class ChattingViewController:
 	
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
-		removeKeyboardNotification()
+		removeKeyboardNotification([keyboardShowNotification, keyboardHideNotification])
 	}
 }
 // MARK: - UI Setting

--- a/GaeManda/Projects/Presentation/OnBoarding/Implementations/AddressSetting/AddressSettingViewController.swift
+++ b/GaeManda/Projects/Presentation/OnBoarding/Implementations/AddressSetting/AddressSettingViewController.swift
@@ -96,6 +96,10 @@ final class AddressSettingViewController:
 		bind()
 	}
 	
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+	}
+	
 	override func setViewHierarchy() {
 		super.setViewHierarchy()
 		contentView.addSubviews(


### PR DESCRIPTION
## 관련 이슈

close #60 

## 작업 설명

- `ThirdDogSettingViewController` 리팩토링입니다.
- 키보드 리스너도 약간 수정했습니다. 기존에 노티피케이션이 등록한 옵저버 삭제가 안 되고 있어서 삭제되게끔 수정했습니다.

**키보드 리스너**
```swift
var keyboardShowNotification: NSObjectProtocol? { get set }
var keyboardHideNotification: NSObjectProtocol? { get set }

@discardableResult
func registerKeyboardShowNotification() -> NSObjectProtocol?

@discardableResult
func registerKeyboardHideNotification() -> NSObjectProtocol?

func removeKeyboardNotification(_ notifications: [NSObjectProtocol?])
```

- 노티피케이션 등록 시 `registerKeyboardShowNotification()`와 `registerKeyboardHideNotification()`의 반환 값을 각각 `keyboardShowNotification`, `keyboardHideNotification`에 저장하면 됩니다.
- 노티피케이션에서 제거 시에는 `keyboardShowNotification`, `keyboardHideNotification`를 `removeKeyboardNotification(_:)`의 인자 값으로 넣어주면 됩니다.

## 스크린샷
<img src="https://github.com/WalkingDogWithFriends/GaeManDa/assets/48887389/53d25cd4-b9e8-4fcd-8281-e4ebce89555a" width="375"/>

## 참고사항
- 텍스트 뷰 포커스 시 아래처럼 뷰가 안 내려가는데 이건 다음 작업에서 고쳐보겠습니다^^ㅎㅎ
<img src="https://github.com/WalkingDogWithFriends/GaeManDa/assets/48887389/cf4ee6a0-00d5-40aa-aac4-a771a0fedf74" width="375"/>


