### PR TITLE
키보드 버그 수정 및 스와이프 뒤로가기 구현

### DIFF
--- a/GaeManda/Projects/Core/GMDExtensions/String+Extension.swift
+++ b/GaeManda/Projects/Core/GMDExtensions/String+Extension.swift
@@ -17,7 +17,7 @@ public extension String {
 	) -> NSAttributedString {
 		let paragraphStyle = NSMutableParagraphStyle()
 		paragraphStyle.lineSpacing = lineSpacing
-		var attributes: [NSAttributedString.Key: Any] = [
+		let attributes: [NSAttributedString.Key: Any] = [
 			.font: font,
 			.foregroundColor: color,
 			.paragraphStyle: paragraphStyle

--- a/GaeManda/Projects/Core/GMDUtils/Base/BaseNavigationController.swift
+++ b/GaeManda/Projects/Core/GMDUtils/Base/BaseNavigationController.swift
@@ -1,0 +1,33 @@
+//
+//  BaseNavigationController.swift
+//  GMDUtils
+//
+//  Created by jung on 9/22/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+
+public protocol SwipeRecognigerDelegate: UIViewController {
+	func swipeRecognigerDismiss()
+}
+
+public final class BaseNavigationController: UINavigationController {
+	public override func viewDidLoad() {
+		super.viewDidLoad()
+		interactivePopGestureRecognizer?.delegate = self
+	}
+}
+
+// MARK: - UIGestureRecognizerDelegate
+extension BaseNavigationController: UIGestureRecognizerDelegate {
+	public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+		if 
+			viewControllers.count > 1,
+			let topViewController = topViewController as? SwipeRecognigerDelegate {
+			topViewController.swipeRecognigerDismiss()
+		}
+		
+		return false
+	}
+}

--- a/GaeManda/Projects/Core/GMDUtils/RIBs+Utils.swift
+++ b/GaeManda/Projects/Core/GMDUtils/RIBs+Utils.swift
@@ -3,7 +3,7 @@ import RIBs
 
 public final class NavigationControllerable: ViewControllable {
 	public var uiviewController: UIViewController { self.navigationController }
-	public let navigationController: UINavigationController
+	public let navigationController: BaseNavigationController
 	public var navigationBarIsHidden: Bool = false {
 		didSet {
 			navigationController.isNavigationBarHidden = navigationBarIsHidden
@@ -11,7 +11,7 @@ public final class NavigationControllerable: ViewControllable {
 	}
 	
 	public init(root: ViewControllable) {
-		let navigation = UINavigationController(rootViewController: root.uiviewController)
+		let navigation = BaseNavigationController(rootViewController: root.uiviewController)
 		self.navigationController = navigation
 		self.navigationController.navigationBar.isHidden = true
 	}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditInteractor.swift
@@ -75,6 +75,10 @@ extension DogProfileEditInteractor {
 		listener?.dogProfileEditDidTapBackButton()
 	}
 	
+	func dismiss() {
+		listener?.dogProfileEditDismiss()
+	}
+	
 	func didTapEndEditButton(dog: Dog) {
 		dependency.userProfileUseCase
 			.updateDog(dog: dog)

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditViewController.swift
@@ -70,7 +70,7 @@ final class DogProfileEditViewController:
 		dogProfileDashBoard.rx.setDelegate(self).disposed(by: disposeBag)
 		
 		setupUI()
-		keyboardShowNotification = registerKeyboardHideNotification()
+		keyboardShowNotification = registerKeyboardShowNotification()
 		keyboardHideNotification = registerKeyboardHideNotification()
 		textDidChangeNotification = registerTextFieldNotification()
 	}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/DogProfileEdit/DogProfileEditViewController.swift
@@ -20,6 +20,7 @@ protocol DogProfileEditPresentableListener: AnyObject {
 	func viewDidLoad()
 	func viewWillAppear()
 	func didTapBackButton()
+	func dismiss()
 	func didTapEndEditButton(dog: Dog)
 	func didTapDogDashBoard(at id: Int)
 }
@@ -281,3 +282,10 @@ extension DogProfileEditViewController: KeyboardListener {
 
 // MARK: - GMDTextFieldListener
 extension DogProfileEditViewController: GMDTextFieldListener { }
+
+// MARK: - SwipeRecognigerDelegate
+extension DogProfileEditViewController: SwipeRecognigerDelegate {
+	func swipeRecognigerDismiss() {
+		listener?.dismiss()
+	}
+}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/NewDogProfile/NewDogProfileInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/NewDogProfile/NewDogProfileInteractor.swift
@@ -55,6 +55,10 @@ extension NewDogProfileInteractor {
 		listener?.newDogProfileDidTapBackButton()
 	}
 	
+	func dismiss() {
+		listener?.newDogProfileDismiss()
+	}
+	
 	func didTapConfirmButton(dog: Dog) {
 		dependency.userProfileUseCase
 			.postNewDog(dog: dog)

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/NewDogProfile/NewDogProfileViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/NewDogProfile/NewDogProfileViewController.swift
@@ -18,6 +18,7 @@ import GMDUtils
 
 protocol NewDogProfilePresentableListener: AnyObject {
 	func didTapBackButton()
+	func dismiss()
 	func didTapConfirmButton(dog: Dog)
 }
 
@@ -179,3 +180,10 @@ extension NewDogProfileViewController: KeyboardListener {
 
 // MARK: - GMDTextFieldListener
 extension NewDogProfileViewController: GMDTextFieldListener { }
+
+// MARK: - SwipeRecognigerDelegate
+extension NewDogProfileViewController: SwipeRecognigerDelegate {
+	func swipeRecognigerDismiss() {
+		listener?.dismiss()
+	}
+}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditInteractor.swift
@@ -19,8 +19,6 @@ protocol UserProfileEditPresentable: Presentable {
 	
 	func updateUsername(_ name: String)
 	func updateUserSex(_ sex: Sex)
-	
-	func userNameIsEmpty()
 }
 
 protocol UserProfileEditInteractorDependency {
@@ -74,17 +72,13 @@ extension UserProfileEditInteractor {
 	
 	func didTapEndEditingButton(name: String, sex: Sex) {
 		debugPrint(name, sex)
-		if name.isEmpty {
-			presenter.userNameIsEmpty()
-		} else {
-			dependency.userProfileUseCase
-				.updateUser(nickName: name, age: 20, sex: sex.rawValue)
-				.observe(on: MainScheduler.instance)
-				.subscribe(with: self) { owner, result in
-					guard result == "success" else { return }
-					owner.listener?.userProfileEndEditing()
-				}
-				.disposeOnDeactivate(interactor: self)
-		}
+		dependency.userProfileUseCase
+			.updateUser(nickName: name, age: 20, sex: sex.rawValue)
+			.observe(on: MainScheduler.instance)
+			.subscribe(with: self) { owner, result in
+				guard result == "success" else { return }
+				owner.listener?.userProfileEndEditing()
+			}
+			.disposeOnDeactivate(interactor: self)
 	}
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditInteractor.swift
@@ -70,6 +70,10 @@ extension UserProfileEditInteractor {
 		listener?.userProfileEditDidTapBackButton()
 	}
 	
+	func dismiss() {
+		listener?.userProfileEditDismiss()
+	}
+	
 	func didTapEndEditingButton(name: String, sex: Sex) {
 		debugPrint(name, sex)
 		dependency.userProfileUseCase

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
@@ -19,6 +19,7 @@ import GMDUtils
 protocol UserProfileEditPresentableListener: AnyObject {
 	func viewWillAppear()
 	func didTapBackbutton()
+	func dismiss()
 	func didTapEndEditingButton(name: String, sex: Sex)
 }
 
@@ -35,13 +36,7 @@ final class UserProfileEditViewController:
 	
 	// MARK: - UI Components
 	private let navigationBar = GMDNavigationBar(title: "프로필 수정")
-	
-	private let profileImageView: RoundImageView = {
-		let roundImageView = RoundImageView()
-		roundImageView.backgroundColor = .gray40
-		
-		return roundImageView
-	}()
+	private let profileImageView = RoundImageView()
 	
 	/// GMDTextField StackView
 	private let textStackView: UIStackView = {
@@ -110,6 +105,7 @@ final class UserProfileEditViewController:
 		
 		hideTabBar()
 	}
+	
 	// MARK: - touchesBegan
 	override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
 		super.touchesBegan(touches, with: event)
@@ -314,5 +310,12 @@ private extension UserProfileEditViewController {
 private extension UserProfileEditViewController {
 	func calenderButtonDidTap() {
 		print("calenderButtonDidTap")
+	}
+}
+
+// MARK: - SwipeRecognigerDelegate
+extension UserProfileEditViewController: SwipeRecognigerDelegate {
+	func swipeRecognigerDismiss() {
+		listener?.dismiss()
 	}
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
@@ -26,12 +26,12 @@ final class UserProfileEditViewController:
 	UIViewController,
 	UserProfileEditPresentable,
 	UserProfileEditViewControllable {
+	// MARK: - Properties
 	weak var listener: UserProfileEditPresentableListener?
 	private let disposeBag = DisposeBag()
 	
-	var userGender: Sex = .male
-	// MARK: - Constant Properties
-	let maxTextCount = 20
+	private let maxTextCount = 20
+	private let selectedSexRelay = BehaviorRelay<Sex>(value: .male)
 	
 	// MARK: - UI Components
 	private let navigationBar = GMDNavigationBar(title: "프로필 수정")
@@ -96,16 +96,7 @@ final class UserProfileEditViewController:
 	private let maleButton = GMDOptionButton(title: "남")
 	private let femaleButton = GMDOptionButton(title: "여")
 	
-	private let endEditingButton: UIButton = {
-		let button = UIButton()
-		button.setTitle("수정 완료", for: .normal)
-		button.setTitleColor(.white, for: .normal)
-		button.layer.cornerRadius = 4
-		button.backgroundColor = .green100
-		button.titleLabel?.font = .b16
-		
-		return button
-	}()
+	private let confirmButton = ConfirmButton(title: "수정 완료")
 	
 	// MARK: - Life Cycle
 	override func viewDidLoad() {
@@ -129,16 +120,18 @@ private extension UserProfileEditViewController {
 		maleButton.isSelected = true
 		
 		/// Set TextField Right View
-		nickNameTextField.textField.rightView = maxTextCountLabel
-		nickNameTextField.textField.rightViewMode = .always
-		
-		calenderTextField.textField.rightView = calenderButton
-		calenderTextField.textField.rightViewMode = .always
+		setTextField(nickNameTextField, rightView: maxTextCountLabel)
+		setTextField(calenderTextField, rightView: calenderButton)
 		
 		setViewHierarchy()
 		setConstraints()
 		bind()
 		bindForUI()
+	}
+	
+	func setTextField(_ textField: GMDTextField, rightView: UIView) {
+		textField.textField.rightView = rightView
+		textField.textField.rightViewMode = .always
 	}
 	
 	func setViewHierarchy() {
@@ -147,7 +140,7 @@ private extension UserProfileEditViewController {
 			profileImageView,
 			textStackView,
 			buttonStackView,
-			endEditingButton
+			confirmButton
 		)
 		
 		textStackView.addArrangedSubviews(nickNameTextField, calenderTextField)
@@ -181,7 +174,7 @@ private extension UserProfileEditViewController {
 			make.height.equalTo(40)
 		}
 		
-		endEditingButton.snp.makeConstraints { make in
+		confirmButton.snp.makeConstraints { make in
 			make.leading.equalToSuperview().offset(32)
 			make.trailing.equalToSuperview().offset(-32)
 			make.bottom.equalToSuperview().offset(-54)
@@ -194,20 +187,10 @@ private extension UserProfileEditViewController {
 extension UserProfileEditViewController {
 	func updateUsername(_ name: String) {
 		nickNameTextField.text = name
-		nickNameTextField.titleLabel.alpha = name.isEmpty ? 0.0 : 1.0
-		maxTextCountLabel.text = "\(name.count)/\(maxTextCount)"
 	}
 	
 	func updateUserSex(_ sex: Sex) {
-		if sex.rawValue == "남" {
-			userGender = .male
-			maleButton.rx.isSelected.onNext(true)
-			femaleButton.rx.isSelected.onNext(false)
-		} else {
-			userGender = .female
-			femaleButton.rx.isSelected.onNext(true)
-			maleButton.rx.isSelected.onNext(false)
-		}
+		selectedSexRelay.accept(sex)
 	}
 	
 	func userNameIsEmpty() {
@@ -223,12 +206,18 @@ private extension UserProfileEditViewController {
 				owner.listener?.didTapBackbutton()
 			}
 			.disposed(by: disposeBag)
+	
+		calenderButton.rx.tap
+			.bind(with: self) { owner, _ in
+				owner.calenderButtonDidTap()
+			}
+			.disposed(by: disposeBag)
 		
-		endEditingButton.rx.tap
+		confirmButton.rx.tap
 			.bind(with: self) { owner, _ in
 				owner.listener?.didTapEndEditingButton(
 					name: owner.nickNameTextField.text,
-					sex: owner.userGender
+					sex: owner.selectedSexRelay.value
 				)
 			}
 			.disposed(by: disposeBag)
@@ -236,48 +225,50 @@ private extension UserProfileEditViewController {
 	
 	// MARK: - UI Binding
 	func bindForUI() {
+		// textField의 text가 지정된 수보다 넘어가면 trimming
 		nickNameTextField.rx.text
 			.orEmpty
 			.withUnretained(self)
-			.map { owner, text -> String in
-				let maxCount = owner.maxTextCount
-				return text.trimmingSuffix(with: maxCount)
+			.map { owner, text -> NSAttributedString in
+				text.trimmingSuffix(with: owner.maxTextCount).inputText()
 			}
-			.bind(to: nickNameTextField.textField.rx.text)
+			.bind(to: nickNameTextField.rx.attributedText)
 			.disposed(by: disposeBag)
-		
+	
+		// textField의 text수를 알려주는 Label에 매핑
 		nickNameTextField.rx.text
 			.orEmpty
 			.withUnretained(self)
-			.map { "\($1.count)/\($0.maxTextCount)" }
-			.bind(to: maxTextCountLabel.rx.text)
+			.map { "\($1.count)/\($0.maxTextCount)".inputText(color: .gray90) }
+			.bind(to: maxTextCountLabel.rx.attributedText)
 			.disposed(by: disposeBag)
 		
+		// calenderTextField가 editing안되도록 해줌.
 		calenderTextField.textField.rx.controlEvent(.editingDidBegin)
 			.map { true }
 			.bind(to: calenderTextField.textField.rx.isEditing)
 			.disposed(by: disposeBag)
 		
-		calenderButton.rx.tap
-			.bind(with: self) { owner, _ in
-				owner.calenderButtonDidTap()
-			}
+		// 성별 버튼 선택 Observable
+		Observable.merge(
+			maleButton.rx.tap.map { Sex.male },
+			femaleButton.rx.tap.map { Sex.female }
+		)
+		.subscribe(with: self) { owner, sex in
+			owner.selectedSexRelay.accept(sex)
+		}
+		.disposed(by: disposeBag)
+		
+		// 남자일 경우
+		selectedSexRelay
+			.map { $0 == .male }
+			.bind(to: maleButton.rx.isSelected)
 			.disposed(by: disposeBag)
 		
-		maleButton.rx.tap
-			.bind(with: self) { owner, _ in
-				owner.userGender = .male
-				owner.maleButton.rx.isSelected.onNext(true)
-				owner.femaleButton.rx.isSelected.onNext(false)
-			}
-			.disposed(by: disposeBag)
-		
-		femaleButton.rx.tap
-			.bind(with: self) { owner, _ in
-				owner.userGender = .female
-				owner.femaleButton.rx.isSelected.onNext(true)
-				owner.maleButton.rx.isSelected.onNext(false)
-			}
+		// 여성일 경우
+		selectedSexRelay
+			.map { $0 == .female }
+			.bind(to: femaleButton.rx.isSelected)
 			.disposed(by: disposeBag)
 	}
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileEdit/UserProfileEditViewController.swift
@@ -110,6 +110,11 @@ final class UserProfileEditViewController:
 		
 		hideTabBar()
 	}
+	// MARK: - touchesBegan
+	override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+		super.touchesBegan(touches, with: event)
+		self.view.endEditing(true)
+	}
 }
 
 // MARK: - UI Setting

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
@@ -119,6 +119,10 @@ extension UserProfileInteractor {
 		router?.newDogProfileDetach()
 	}
 	
+	func newDogProfileDismiss() {
+		router?.newDogProfileDetach()
+	}
+	
 	func newDogProfileDidTapConfirmButton() {
 		router?.newDogProfileDetach()
 	}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
@@ -92,6 +92,10 @@ extension UserProfileInteractor {
 	func userProfileEndEditing() {
 		router?.userProfileEditDetach()
 	}
+	
+	func userProfileEditDismiss() {
+		router?.userProfileEditDetach()
+	}
 }
 
 // MARK: - DogProfileEditListener

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileInteractor.swift
@@ -104,6 +104,10 @@ extension UserProfileInteractor {
 		router?.dogProfileEditDetach()
 	}
 	
+	func dogProfileEditDismiss() {
+		router?.dogProfileEditDetach()
+	}
+	
 	func dogProfileEndEditing() {
 		router?.dogProfileEditDetach()
 	}

--- a/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileRouter.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Implementations/UserProfileRouter.swift
@@ -8,6 +8,7 @@
 
 import RIBs
 import GMDProfile
+import GMDUtils
 
 protocol UserProfileInteractable:
 	Interactable,
@@ -51,13 +52,10 @@ final class UserProfileRouter:
 extension UserProfileRouter {
 	func userProfileEditAttach() {
 		if userProfileEditRouting != nil { return }
-		
+
 		let router = userProfileEditBuildable.build(withListener: interactor)
-		viewController.pushViewController(
-			router.viewControllable,
-			animated: true
-		)
-		
+		pushViewController(router.viewControllable)
+
 		userProfileEditRouting = router
 		attachChild(router)
 	}
@@ -80,10 +78,7 @@ extension UserProfileRouter {
 			withListener: interactor,
 			selectedDogId: selectedId
 		)
-		viewController.pushViewController(
-			router.viewControllable,
-			animated: true
-		)
+		pushViewController(router.viewControllable)
 		
 		dogProfileEditRouting = router
 		attachChild(router)
@@ -104,10 +99,7 @@ extension UserProfileRouter {
 		if newDogProfileRouting != nil { return }
 		
 		let router = newDogProfileBuildable.build(withListener: interactor)
-		viewController.pushViewController(
-			router.viewControllable,
-			animated: true
-		)
+		pushViewController(router.viewControllable)
 		
 		newDogProfileRouting = router
 		attachChild(router)
@@ -119,5 +111,15 @@ extension UserProfileRouter {
 		router.viewControllable.popViewController(animated: true)
 		newDogProfileRouting = nil
 		detachChild(router)
+	}
+}
+
+// MARK: - Private Extension
+private extension UserProfileRouter {
+	func pushViewController(_ viewControllable: ViewControllable) {
+		viewController.pushViewController(
+			viewControllable,
+			animated: true
+		)
 	}
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Interfaces/DogProfileEdit.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Interfaces/DogProfileEdit.swift
@@ -18,4 +18,5 @@ public protocol DogProfileEditBuildable: Buildable {
 public protocol DogProfileEditListener: AnyObject {
 	func dogProfileEditDidTapBackButton()
 	func dogProfileEndEditing()
+	func dogProfileEditDismiss()
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Interfaces/NewDogProfile.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Interfaces/NewDogProfile.swift
@@ -15,4 +15,5 @@ public protocol NewDogProfileBuildable: Buildable {
 public protocol NewDogProfileListener: AnyObject {
 	func newDogProfileDidTapBackButton()
 	func newDogProfileDidTapConfirmButton()
+	func newDogProfileDismiss()
 }

--- a/GaeManda/Projects/Presentation/GMDProfile/Interfaces/UserProfileEdit.swift
+++ b/GaeManda/Projects/Presentation/GMDProfile/Interfaces/UserProfileEdit.swift
@@ -15,4 +15,5 @@ public protocol UserProfileEditBuildable: Buildable {
 public protocol UserProfileEditListener: AnyObject {
 	func userProfileEditDidTapBackButton()
 	func userProfileEndEditing()
+	func userProfileEditDismiss()
 }


### PR DESCRIPTION
## 관련 이슈

- #82 

## 작업 설명
- `UserEditViewController`에서 외부터치시 키보드가 안내려가는 버그 수정했습니다. 
- `BaseNavigationController`를 통해 Swipe Back을 통해 detach 되도록 구현했습니다.

### BaseNavigationController
사용 방법은 다음과 같습니다. 

다음과 같이 `viewControllable`를 `NavigationControllable`로 감싸줍니다.
``` Swift
NavigationControllerable(root: userSettingRouting.viewControllable)
```

다음으로 해당 `ViewController`에서 `SwipeRecognigerDelegate`를 채택해줍니다. 
``` Swift
extension ViewController: SwipeRecognigerDelegate {
	func swipeRecognigerDismiss() {
		listener?.dismiss()
	}
}
```

마지막으로 `listener`에선 해당 리블렛을 detach해주면 됩니다. 
detach과정은 backButton을 눌렀을 때와 같습니다. 
``` Swift
	func userProfileEditDidTapBackButton() {
		router?.userProfileEditDetach()
	}
	
	func userProfileEditDismiss() {
		router?.userProfileEditDetach()
	}
```