### PR TITLE
DropDownView 구현

### DIFF
--- a/GaeManda/Projects/Core/GMDExtensions/UIKit/UIWindow+Extension.swift
+++ b/GaeManda/Projects/Core/GMDExtensions/UIKit/UIWindow+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  UIWindow+Extension.swift
+//  GMDExtensions
+//
+//  Created by jung on 10/18/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+
+public extension UIWindow {
+	/// 가장 상위의 `UIWindow`를 반환합니다.
+	/// 찾지 못하였을 경우 `nil`을 반환합니다.
+	static var key: UIWindow? {
+		if #available(iOS 13, *) {
+			return UIApplication.shared.connectedScenes
+				.compactMap { $0 as? UIWindowScene }
+				.flatMap { $0.windows }
+				.first { $0.isKeyWindow }
+		} else {
+			return UIApplication.shared.keyWindow
+		}
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
@@ -1,0 +1,97 @@
+//
+//  DropDownButton.swift
+//  DesignKit
+//
+//  Created by jung on 10/16/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+import GMDExtensions
+
+final class DropDownButton: UIView {
+	// MARK: - DropDownTextMode
+	enum DropDownTextMode {
+		case title
+		case option
+	}
+	
+	// MARK: - Properties
+	var textMode: DropDownTextMode = .title {
+		didSet {
+			switch textMode {
+			case .title:
+				label.textColor = .gray90
+			case .option:
+				label.textColor = .black
+			}
+		}
+	}
+	
+	// MARK: - UI Components
+	private let label: UILabel = {
+		let label = UILabel()
+		label.textColor = .black
+		label.font = .r15
+		
+		return label
+	}()
+
+	private let downImageView: UIImageView = {
+		let imageView = UIImageView(
+			image: UIImage(systemName: "chevron.down")
+		)
+		imageView.tintColor = .gray90
+		
+		return imageView
+	}()
+	
+	// MARK: - Initializers
+	init() {
+		super.init(frame: .zero)
+		layer.cornerRadius = 4
+		layer.borderWidth = 1
+		layer.borderColor = UIColor.gray90.cgColor
+		
+		setupUI()
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+// MARK: - UI Methods
+private extension DropDownButton {
+	func setupUI() {
+		setViewHierarchy()
+		setConstraints()
+	}
+	
+	func setViewHierarchy() {
+		addSubviews(label, downImageView)
+	}
+	
+	func setConstraints() {
+		label.snp.makeConstraints { make in
+			make.leading.equalToSuperview().offset(8)
+			make.top.equalToSuperview().offset(12)
+			make.bottom.equalToSuperview().offset(-12)
+		}
+		
+		downImageView.snp.makeConstraints { make in
+			make.centerY.equalTo(label)
+			make.trailing.equalToSuperview().offset(-12)
+		}
+	}
+}
+
+// MARK: - Internel Methods
+extension DropDownButton {
+	func setTitle(_ title: String, for mode: DropDownTextMode) {
+		self.textMode = mode
+		self.label.text = title
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownCell.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownCell.swift
@@ -1,0 +1,62 @@
+//
+//  DropDownCell.swift
+//  DesignKit
+//
+//  Created by jung on 10/17/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+final class DropDownCell: UITableViewCell {
+	override var isSelected: Bool {
+		didSet {
+			optionLabel.textColor = isSelected ? .black : .gray90
+		}
+	}
+	
+	// MARK: - UI Components
+	private let optionLabel: UILabel = {
+		let label = UILabel()
+		label.font = .r12
+		
+		return label
+	}()
+	
+	// MARK: - Initializers
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		self.selectionStyle = .none
+		setupUI()
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError()
+	}
+	
+	// MARK: - Configure
+	func configure(with text: String) {
+		optionLabel.text = text
+	}
+}
+
+// MARK: - UI Methods
+private extension DropDownCell {
+	func setupUI() {
+		setViewHierarchy()
+		setConstraints()
+	}
+	
+	func setViewHierarchy() {
+		contentView.addSubview(optionLabel)
+	}
+	
+	func setConstraints() {
+		optionLabel.snp.makeConstraints { make in
+			make.leading.top.equalToSuperview().offset(8)
+			make.bottom.equalToSuperview().offset(-8)
+		}
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
@@ -12,12 +12,12 @@ public protocol DropDownListener: AnyObject {
 	var dropDownViews: [DropDownView]? { get set }
 	
 	func hit(at hitView: UIView)
-	func registerDronDrownViews(_ dropDownViews: [DropDownView])
+	func registerDropDrownViews(_ dropDownViews: [DropDownView])
 	func dropdown(_ dropDown: DropDownView, didSelectRowAt indexPath: IndexPath)
 }
 
 public extension DropDownListener where Self: UIViewController {
-	func registerDronDrownViews(_ dropDownViews: [DropDownView]) {
+	func registerDropDrownViews(_ dropDownViews: [DropDownView]) {
 		self.dropDownViews = dropDownViews
 		dropDownViews.forEach { $0.listener = self }
 	}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
@@ -6,4 +6,31 @@
 //  Copyright © 2023 com.gaemanda. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+public protocol DropDownListener: AnyObject { 
+	var dropDownViews: [DropDownView]? { get set }
+	
+	func hit(at hitView: UIView)
+	func registerDronDrownViews(_ dropDownViews: [DropDownView])
+	func dropdown(_ dropDown: DropDownView, didSelectRowAt indexPath: IndexPath)
+}
+
+public extension DropDownListener where Self: UIViewController {
+	func registerDronDrownViews(_ dropDownViews: [DropDownView]) {
+		self.dropDownViews = dropDownViews
+		dropDownViews.forEach { $0.listener = self }
+	}
+	
+	func hit(at hitView: UIView) {
+		dropDownViews?.forEach { view in
+			if
+				let hitSuperView = hitView.superview?.superview,
+				view === hitSuperView {
+				view.isDisplayed.toggle()
+			} else {
+				view.isDisplayed = false
+			}
+		}
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
@@ -1,0 +1,9 @@
+//
+//  DropDownListener.swift
+//  DesignKit
+//
+//  Created by jung on 10/17/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import Foundation

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
@@ -25,7 +25,7 @@ public extension DropDownListener where Self: UIViewController {
 	func hit(at hitView: UIView) {
 		dropDownViews?.forEach { view in
 			if
-				let hitSuperView = hitView.superview?.superview,
+				let hitSuperView = hitView.superview,
 				view === hitSuperView {
 				view.isDisplayed.toggle()
 			} else {

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownTableView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownTableView.swift
@@ -1,0 +1,42 @@
+//
+//  DropDownTableView.swift
+//  DesignKit
+//
+//  Created by jung on 10/17/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+import GMDExtensions
+
+final class DropDownTableView: UITableView {
+	// MARK: - Initializers
+	override init(frame: CGRect, style: UITableView.Style) {
+		super.init(frame: frame, style: style)
+		
+		layer.cornerRadius = 4
+		layer.borderWidth = 1
+		layer.borderColor = UIColor.gray90.cgColor
+		separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+		registerCell(DropDownCell.self)
+		
+		self.rowHeight = 32
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	// MARK: - Methods
+	func deselectAllCell() {
+		self.visibleCells.forEach { $0.isSelected = false }
+	}
+	
+	func selectRow(at index: Int) {
+		deselectAllCell()
+		self.visibleCells.enumerated().forEach { (idx, cell) in
+			if index == idx { cell.isSelected = true }
+		}
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -1,0 +1,9 @@
+//
+//  DropDownView.swift
+//  DesignKit
+//
+//  Created by jung on 10/17/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import Foundation

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -6,4 +6,158 @@
 //  Copyright © 2023 com.gaemanda. All rights reserved.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import GMDExtensions
+
+public final class DropDownView: UIView {
+	// MARK: - Properties
+	/// DropDownView에서 button의 buttom Constraint를 리턴합니다.
+	public var viewBottom: ConstraintItem {
+		self.dropDownButton.snp.bottom
+	}
+
+	/// DropDown을 띄울지 여부입니다.
+	public var isDisplayed: Bool {
+		didSet { 
+			isDisplayed ? displayDropDown() : hideDropDown()
+		}
+	}
+	
+	/// DropDown에 띄울 목록들을 정의합니다.
+	public var dataSource = [String]() {
+		didSet {
+			updateDropDownTableViewHeight()
+			dropDownTableView.reloadData()
+		}
+	}
+	
+	/// DropDown의 title을 정의할 수 있습니다.
+	public var title: String? {
+		didSet {
+			guard let title = title else { return }
+			dropDownButton.setTitle(title, for: .title)
+		}
+	}
+	
+	/// DropDown의 현재 선택된 항목을 알 수 있습니다.
+	public private(set) var selectedOption: String? {
+		didSet {
+			guard let option = selectedOption else { return }
+			dropDownButton.setTitle(option, for: .option)
+		}
+	}
+		
+	// MARK: - UI Components
+	private let stackView: UIStackView = {
+		let stackView = UIStackView()
+		stackView.axis = .vertical
+		stackView.alignment = .fill
+		stackView.distribution = .equalSpacing
+		stackView.spacing = 0
+		
+		return stackView
+	}()
+	
+	private let dropDownButton = DropDownButton()
+	private let dropDownTableView = DropDownTableView()
+	
+	// MARK: - Initializers
+	public init(isDisplayed: Bool = false) {
+		self.isDisplayed = isDisplayed
+		super.init(frame: .zero)
+		dropDownTableView.isHidden = true
+		dropDownTableView.dataSource = self
+		dropDownTableView.delegate = self
+		
+		setupUI()
+	}
+	
+	convenience public init(
+		title: String? = nil,
+		selectedOption: String? = nil
+	) {
+		self.init()
+		
+		defer {
+			self.title = title
+			self.selectedOption = selectedOption
+		}
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+// MARK: - UI Methods
+private extension DropDownView {
+	func setupUI() {
+		setViewHierarchy()
+		setConstraints()
+	}
+	
+	func setViewHierarchy() {
+		addSubview(stackView)
+		stackView.addArrangedSubviews(dropDownButton, dropDownTableView)
+	}
+	
+	func setConstraints() {
+		stackView.snp.makeConstraints { make in
+			make.edges.equalToSuperview()
+		}
+		
+		dropDownTableView.snp.makeConstraints { make in
+			make.height.equalTo(0)
+		}
+	}
+}
+
+// MARK: - UITableViewDelegate
+extension DropDownView: UITableViewDataSource {
+	public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		return dataSource.count
+	}
+	
+	public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		let cell = tableView.dequeueCell(DropDownCell.self, for: indexPath)
+		if let selectedOption = self.selectedOption,
+			 selectedOption == dataSource[indexPath.row] {
+			cell.isSelected = true
+		}
+		
+		cell.configure(with: dataSource[indexPath.row])
+		
+		return cell
+	}
+}
+
+// MARK: - UITableViewDataSource
+extension DropDownView: UITableViewDelegate {
+	public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		selectedOption = dataSource[indexPath.row]
+		dropDownTableView.selectRow(at: indexPath.row)
+		hideDropDown()
+	}
+}
+
+// MARK: - DropDown Logic
+extension DropDownView {
+	private func updateDropDownTableViewHeight() {
+		let height = min(CGFloat(dataSource.count) * 32, 160)
+		UIView.animate(withDuration: 0.3) {
+			self.dropDownTableView.snp.updateConstraints { make in
+				make.height.equalTo(height)
+			}
+		}
+	}
+	
+	public func hideDropDown() {
+		dropDownTableView.isHidden = true
+	}
+	
+	public func displayDropDown() {
+		dropDownTableView.isHidden = false
+	}
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -156,10 +156,12 @@ extension DropDownView {
 		}
 	}
 	
+	/// DropDownList를 숨김니다.
 	public func hideDropDown() {
 		dropDownTableView.isHidden = true
 	}
 	
+	/// DropDownList를 보여줍니다.
 	public func displayDropDown() {
 		dropDownTableView.isHidden = false
 	}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -20,8 +20,8 @@ public final class DropDownView: UIView {
 	}
 
 	/// DropDown을 띄울지 여부입니다.
-	public var isDisplayed: Bool {
-		didSet { 
+	public var isDisplayed: Bool = false {
+		didSet {
 			isDisplayed ? displayDropDown() : hideDropDown()
 		}
 	}
@@ -35,7 +35,7 @@ public final class DropDownView: UIView {
 	}
 		
 	/// DropDown의 현재 선택된 항목을 알 수 있습니다.
-	public private(set) var selectedOption: String? = nil
+	public private(set) var selectedOption: String?
 		
 	// MARK: - UI Components
 	private let stackView: UIStackView = {
@@ -52,13 +52,10 @@ public final class DropDownView: UIView {
 	private let dropDownTableView = DropDownTableView()
 	
 	// MARK: - Initializers
-	public init(isDisplayed: Bool = false) {
-		self.isDisplayed = isDisplayed
+	public init() {
 		super.init(frame: .zero)
-		dropDownTableView.isHidden = true
 		dropDownTableView.dataSource = self
 		dropDownTableView.delegate = self
-		
 		setupUI()
 	}
 	
@@ -82,22 +79,18 @@ public final class DropDownView: UIView {
 // MARK: - UI Methods
 private extension DropDownView {
 	func setupUI() {
+		dropDownTableView.backgroundColor = .red
 		setViewHierarchy()
 		setConstraints()
 	}
 	
 	func setViewHierarchy() {
-		addSubview(stackView)
-		stackView.addArrangedSubviews(dropDownButton, dropDownTableView)
+		addSubview(dropDownButton)
 	}
 	
 	func setConstraints() {
-		stackView.snp.makeConstraints { make in
+		dropDownButton.snp.makeConstraints { make in
 			make.edges.equalToSuperview()
-		}
-		
-		dropDownTableView.snp.makeConstraints { make in
-			make.height.equalTo(0)
 		}
 	}
 }
@@ -128,7 +121,7 @@ extension DropDownView: UITableViewDelegate {
 		selectedOption = dataSource[indexPath.row]
 		dropDownTableView.selectRow(at: indexPath.row)
 		setButtonOption(selectedOption)
-		hideDropDown()
+		isDisplayed = false
 	}
 }
 
@@ -145,12 +138,20 @@ extension DropDownView {
 	
 	/// DropDownList를 숨김니다.
 	public func hideDropDown() {
-		dropDownTableView.isHidden = true
+		dropDownTableView.removeFromSuperview()
+		dropDownTableView.snp.removeConstraints()
 	}
 	
 	/// DropDownList를 보여줍니다.
 	public func displayDropDown() {
-		dropDownTableView.isHidden = false
+		UIWindow.key?.addSubview(dropDownTableView)
+		dropDownTableView.snp.makeConstraints { make in
+			make.width.equalTo(dropDownButton.snp.width)
+			make.leading.equalTo(dropDownButton)
+			make.top.equalTo(viewBottom)
+			make.height.equalTo(0)
+		}
+		updateDropDownTableViewHeight()
 	}
 	
 	/// DropDownButton의 Title을 설정합니다.

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -33,22 +33,9 @@ public final class DropDownView: UIView {
 			dropDownTableView.reloadData()
 		}
 	}
-	
-	/// DropDown의 title을 정의할 수 있습니다.
-	public var title: String? {
-		didSet {
-			guard let title = title else { return }
-			dropDownButton.setTitle(title, for: .title)
-		}
-	}
-	
+		
 	/// DropDown의 현재 선택된 항목을 알 수 있습니다.
-	public private(set) var selectedOption: String? {
-		didSet {
-			guard let option = selectedOption else { return }
-			dropDownButton.setTitle(option, for: .option)
-		}
-	}
+	public private(set) var selectedOption: String? = nil
 		
 	// MARK: - UI Components
 	private let stackView: UIStackView = {
@@ -80,11 +67,10 @@ public final class DropDownView: UIView {
 		selectedOption: String? = nil
 	) {
 		self.init()
+		self.selectedOption = selectedOption
 		
-		defer {
-			self.title = title
-			self.selectedOption = selectedOption
-		}
+		self.setButtonTitle(title)
+		self.setButtonOption(selectedOption)
 	}
 	
 	@available(*, unavailable)
@@ -141,6 +127,7 @@ extension DropDownView: UITableViewDelegate {
 		listener?.dropdown(self, didSelectRowAt: indexPath)
 		selectedOption = dataSource[indexPath.row]
 		dropDownTableView.selectRow(at: indexPath.row)
+		setButtonOption(selectedOption)
 		hideDropDown()
 	}
 }
@@ -164,5 +151,17 @@ extension DropDownView {
 	/// DropDownList를 보여줍니다.
 	public func displayDropDown() {
 		dropDownTableView.isHidden = false
+	}
+	
+	/// DropDownButton의 Title을 설정합니다.
+	public func setButtonTitle(_ title: String?) {
+		guard let title = title else { return }
+		dropDownButton.setTitle(title, for: .title)
+	}
+	
+	/// DropDownButton의 Title을 선택된 Option으로 설정합니다.
+	public func setButtonOption(_ selectedOption: String?) {
+		guard let selectedOption = selectedOption else { return }
+		dropDownButton.setTitle(selectedOption, for: .option)
 	}
 }

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -12,6 +12,8 @@ import GMDExtensions
 
 public final class DropDownView: UIView {
 	// MARK: - Properties
+	public weak var listener: DropDownListener?
+	
 	/// DropDownView에서 button의 buttom Constraint를 리턴합니다.
 	public var viewBottom: ConstraintItem {
 		self.dropDownButton.snp.bottom
@@ -136,6 +138,7 @@ extension DropDownView: UITableViewDataSource {
 // MARK: - UITableViewDataSource
 extension DropDownView: UITableViewDelegate {
 	public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		listener?.dropdown(self, didSelectRowAt: indexPath)
 		selectedOption = dataSource[indexPath.row]
 		dropDownTableView.selectRow(at: indexPath.row)
 		hideDropDown()


### PR DESCRIPTION
## 관련 이슈

- #106 

## 작업 설명

DropDownView를 구현했습니다. 

<img src="https://github.com/WalkingDogWithFriends/GaeManDa/assets/81402827/24786af7-ab79-4cc5-ad12-3b40243e08f6"  width="200">

title의 경우 gray색상으로, 
선택된 옵션의 경우 검정색으로 표기됩니다. 


사용은 다음과 같습니다. 
```Swift
// 초기에 선택된 옵션이 없는 경우
let dropDownView = DropDownView(title: "우리 아이 종")

// 초기에 선택된 옵션이 있는 경우
let dropDownView2 = DropDownView(selectedOption: "시츄")
```
다음으로 `DropDownListener`프로토콜을 채택해줍니다. 
```Swift
extension ViewController: DropDownListener
```

이후 `ViewController`의 `ViewDidLoad`에서 다음 함수를 호출합니다. 
```Swift
override func viewDidLoad() {
	...
	registerDropDrownViews([dropDownView, dropDownView2])
	...
}
```

이후 `ViewController`의 `touchesBegan`에서 `DropDownListener`의 `hit` 함수를 호출합니다. 
```Swift 
override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
	super.touchesBegan(touches, with: event)
	
	guard
		let touch = touches.first,
		let hitView = self.view.hitTest(touch.location(in: view), with: event)
	else { return }
	self.hit(at: hitView)
}
```

`DropDownList`에서 선택하게 되면 `Listener`에게 `dropdown(_:didSelectRowAt:)` 함수를 통해 전달됩니다. 

추가적으로 현재 선택되어있는 옵션을 알고 싶다면, 
`DropDownView`의 `selectedOption`프로퍼티를 통해 알 수 있습니다.


## PR 특이 사항
- 현재 `button.setTitle`을 `DropDownView`의 `title`, `selectedOption`의 `didSet`을 통해 호출해줍니다.  이 둘을 메서드 방식으로 구현하는게 더 좋을지, 아니면 현재 방식대로 didSet으로 변경이 더 좋을지 한번 봐주면 좋겠슴다.

현재 방식 
``` Swift 
public var title: String? {
	didSet {
		guard let title = title else { return }
		dropDownButton.setTitle(title, for: .title)
	}
}

public private(set) var selectedOption: String? {
	didSet {
		guard let option = selectedOption else { return }
		dropDownButton.setTitle(option, for: .option)
	}
}
```

고민하고 있는 방식 
```Swift
// DropDownView.Swift
public func setButtonTitle(_ title: String) {
	dropDownButton.setTitle(option, for: .option)
}

public func setButtonOption(_ title: String) {
	dropDownButton.setTitle(option, for: .option)
}
```

