### PR TITLE
DropDownView 리팩토링

### DIFF
--- a/GaeManda/Projects/DesignKit/Sources/DropDown/AnchorView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/AnchorView.swift
@@ -1,0 +1,17 @@
+//
+//  AnchorView.swift
+//  DesignKit
+//
+//  Created by jung on 10/22/23.
+//  Copyright © 2023 com.gaemanda. All rights reserved.
+//
+
+import UIKit
+
+public protocol AnchorView: AnyObject {
+	var plainView: UIView { get }
+}
+
+extension UIView: AnchorView {
+	public var plainView: UIView { return self }
+}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
@@ -7,16 +7,17 @@
 //
 
 import UIKit
+import RxSwift
 import SnapKit
 import GMDExtensions
 
+// MARK: - DropDownTextMode
+public enum DropDownTextMode {
+	case title
+	case option
+}
+
 public final class DropDownButton: UIView {
-	// MARK: - DropDownTextMode
-	public enum DropDownTextMode {
-		case title
-		case option
-	}
-	
 	// MARK: - Properties
 	public var textMode: DropDownTextMode = .title {
 		didSet {
@@ -98,5 +99,13 @@ public extension DropDownButton {
 	func setTitle(_ title: String?, for mode: DropDownTextMode) {
 		self.textMode = mode
 		self.label.text = title
+	}
+}
+
+public extension Reactive where Base: DropDownButton {
+	var title: Binder<(title: String?, mode: DropDownTextMode)> {
+		return Binder(self.base) { button, arguments in
+			button.setTitle(arguments.title, for: arguments.mode)
+		}
 	}
 }

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownButton.swift
@@ -10,15 +10,15 @@ import UIKit
 import SnapKit
 import GMDExtensions
 
-final class DropDownButton: UIView {
+public final class DropDownButton: UIView {
 	// MARK: - DropDownTextMode
-	enum DropDownTextMode {
+	public enum DropDownTextMode {
 		case title
 		case option
 	}
 	
 	// MARK: - Properties
-	var textMode: DropDownTextMode = .title {
+	public var textMode: DropDownTextMode = .title {
 		didSet {
 			switch textMode {
 			case .title:
@@ -48,13 +48,18 @@ final class DropDownButton: UIView {
 	}()
 	
 	// MARK: - Initializers
-	init() {
+	public init() {
 		super.init(frame: .zero)
 		layer.cornerRadius = 4
 		layer.borderWidth = 1
 		layer.borderColor = UIColor.gray90.cgColor
 		
 		setupUI()
+	}
+	
+	public convenience init(text: String, mode: DropDownTextMode) {
+		self.init()
+		setTitle(text, for: mode)
 	}
 	
 	@available(*, unavailable)
@@ -88,9 +93,9 @@ private extension DropDownButton {
 	}
 }
 
-// MARK: - Internel Methods
-extension DropDownButton {
-	func setTitle(_ title: String, for mode: DropDownTextMode) {
+// MARK: - Public Methods
+public extension DropDownButton {
+	func setTitle(_ title: String?, for mode: DropDownTextMode) {
 		self.textMode = mode
 		self.label.text = title
 	}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownListener.swift
@@ -25,8 +25,7 @@ public extension DropDownListener where Self: UIViewController {
 	func hit(at hitView: UIView) {
 		dropDownViews?.forEach { view in
 			if
-				let hitSuperView = hitView.superview,
-				view === hitSuperView {
+				view.anchorView === hitView {
 				view.isDisplayed.toggle()
 			} else {
 				view.isDisplayed = false

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownTableView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownTableView.swift
@@ -10,6 +10,10 @@ import UIKit
 import GMDExtensions
 
 final class DropDownTableView: UITableView {
+	// MARK: - Properties
+	private let minHeight: CGFloat = 0
+	private let maxHeight: CGFloat = 192
+	
 	// MARK: - Initializers
 	override init(frame: CGRect, style: UITableView.Style) {
 		super.init(frame: frame, style: style)
@@ -28,7 +32,28 @@ final class DropDownTableView: UITableView {
 		fatalError("init(coder:) has not been implemented")
 	}
 	
-	// MARK: - Methods
+	// MARK: - override Layout Methods
+	override public func layoutSubviews() {
+		super.layoutSubviews()
+		if bounds.size != intrinsicContentSize {
+			invalidateIntrinsicContentSize()
+		}
+	}
+	
+	override public var intrinsicContentSize: CGSize {
+		layoutIfNeeded()
+		if contentSize.height > maxHeight {
+			return CGSize(width: contentSize.width, height: maxHeight)
+		} else if contentSize.height < minHeight {
+			return CGSize(width: contentSize.width, height: minHeight)
+		} else {
+			return contentSize
+		}
+	}
+}
+
+// MARK: - Internal Methods
+extension DropDownTableView {
 	func deselectAllCell() {
 		self.visibleCells.forEach { $0.isSelected = false }
 	}

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import RxCocoa
+import RxSwift
 import SnapKit
 import GMDExtensions
 
@@ -30,20 +31,15 @@ public final class DropDownView: UIView {
 	public var dataSource = [String]() {
 		didSet { dropDownTableView.reloadData() }
 	}
-	
-	public let selectedOptionRelay: PublishRelay<String?>
 		
 	/// DropDown의 현재 선택된 항목을 알 수 있습니다.
-	public private(set) var selectedOption: String? {
-		didSet { selectedOptionRelay.accept(selectedOption) }
-	}
-		
+	public private(set) var selectedOption: String?
+	
 	// MARK: - UI Components
-	private let dropDownTableView = DropDownTableView()
+	fileprivate let dropDownTableView = DropDownTableView()
 	
 	// MARK: - Initializers
 	public init() {
-		self.selectedOptionRelay = PublishRelay()
 		super.init(frame: .zero)
 		dropDownTableView.dataSource = self
 		dropDownTableView.delegate = self
@@ -52,7 +48,6 @@ public final class DropDownView: UIView {
 	convenience public init(selectedOption: String) {
 		self.init()
 		self.selectedOption = selectedOption
-		self.selectedOptionRelay.accept(selectedOption)
 	}
 	
 	@available(*, unavailable)
@@ -108,5 +103,13 @@ extension DropDownView {
 	
 	public func setConstraints(_ closure: @escaping (_ make: ConstraintMaker) -> Void) {
 		self.dropDownConstraints = closure
+	}
+}
+
+public extension Reactive where Base: DropDownView {
+	var selectedOption: ControlEvent<String> {
+		let source = base.dropDownTableView.rx.itemSelected.map { base.dataSource[$0.row] }
+		
+		return ControlEvent(events: source)
 	}
 }

--- a/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
+++ b/GaeManda/Projects/DesignKit/Sources/DropDown/DropDownView.swift
@@ -7,67 +7,52 @@
 //
 
 import UIKit
+import RxCocoa
 import SnapKit
 import GMDExtensions
 
 public final class DropDownView: UIView {
 	// MARK: - Properties
 	public weak var listener: DropDownListener?
+	public weak var anchorView: AnchorView?
 	
-	/// DropDownView에서 button의 buttom Constraint를 리턴합니다.
-	public var viewBottom: ConstraintItem {
-		self.dropDownButton.snp.bottom
-	}
-
-	/// DropDown을 띄울지 여부입니다.
+	/// DropDown을 띄울 Constraint를 적용합니다.
+	private var dropDownConstraints: ((ConstraintMaker) -> Void)?
+	
+	/// DropDown을 display할지 결정합니다.
 	public var isDisplayed: Bool = false {
 		didSet {
-			isDisplayed ? displayDropDown() : hideDropDown()
+			isDisplayed ? displayDropDown(with: dropDownConstraints) : hideDropDown()
 		}
 	}
-	
+
 	/// DropDown에 띄울 목록들을 정의합니다.
 	public var dataSource = [String]() {
-		didSet {
-			updateDropDownTableViewHeight()
-			dropDownTableView.reloadData()
-		}
+		didSet { dropDownTableView.reloadData() }
 	}
+	
+	public let selectedOptionRelay: PublishRelay<String?>
 		
 	/// DropDown의 현재 선택된 항목을 알 수 있습니다.
-	public private(set) var selectedOption: String?
+	public private(set) var selectedOption: String? {
+		didSet { selectedOptionRelay.accept(selectedOption) }
+	}
 		
 	// MARK: - UI Components
-	private let stackView: UIStackView = {
-		let stackView = UIStackView()
-		stackView.axis = .vertical
-		stackView.alignment = .fill
-		stackView.distribution = .equalSpacing
-		stackView.spacing = 0
-		
-		return stackView
-	}()
-	
-	private let dropDownButton = DropDownButton()
 	private let dropDownTableView = DropDownTableView()
 	
 	// MARK: - Initializers
 	public init() {
+		self.selectedOptionRelay = PublishRelay()
 		super.init(frame: .zero)
 		dropDownTableView.dataSource = self
 		dropDownTableView.delegate = self
-		setupUI()
 	}
 	
-	convenience public init(
-		title: String? = nil,
-		selectedOption: String? = nil
-	) {
+	convenience public init(selectedOption: String) {
 		self.init()
 		self.selectedOption = selectedOption
-		
-		self.setButtonTitle(title)
-		self.setButtonOption(selectedOption)
+		self.selectedOptionRelay.accept(selectedOption)
 	}
 	
 	@available(*, unavailable)
@@ -76,25 +61,7 @@ public final class DropDownView: UIView {
 	}
 }
 
-// MARK: - UI Methods
-private extension DropDownView {
-	func setupUI() {
-		setViewHierarchy()
-		setConstraints()
-	}
-	
-	func setViewHierarchy() {
-		addSubview(dropDownButton)
-	}
-	
-	func setConstraints() {
-		dropDownButton.snp.makeConstraints { make in
-			make.edges.equalToSuperview()
-		}
-	}
-}
-
-// MARK: - UITableViewDelegate
+// MARK: - UITableViewDataSource
 extension DropDownView: UITableViewDataSource {
 	public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		return dataSource.count
@@ -119,52 +86,27 @@ extension DropDownView: UITableViewDelegate {
 		listener?.dropdown(self, didSelectRowAt: indexPath)
 		selectedOption = dataSource[indexPath.row]
 		dropDownTableView.selectRow(at: indexPath)
-		setButtonOption(selectedOption)
 		isDisplayed = false
 	}
 }
 
 // MARK: - DropDown Logic
 extension DropDownView {
+	/// DropDownList를 보여줍니다.
+	public func displayDropDown(with constraints: ((ConstraintMaker) -> Void)?) {
+		guard let constraints = constraints else { return }
+				
+		UIWindow.key?.addSubview(dropDownTableView)
+		dropDownTableView.snp.makeConstraints(constraints)
+	}
+	
 	/// DropDownList를 숨김니다.
 	public func hideDropDown() {
 		dropDownTableView.removeFromSuperview()
 		dropDownTableView.snp.removeConstraints()
 	}
 	
-	/// DropDownList를 보여줍니다.
-	public func displayDropDown() {
-		UIWindow.key?.addSubview(dropDownTableView)
-
-		dropDownTableView.snp.makeConstraints { make in
-			make.width.equalTo(dropDownButton.snp.width)
-			make.leading.equalTo(dropDownButton)
-			make.top.equalTo(viewBottom)
-			make.height.equalTo(self.getTableViewHeight())
-		}
-	}
-	
-	/// DropDownButton의 Title을 설정합니다.
-	public func setButtonTitle(_ title: String?) {
-		guard let title = title else { return }
-		dropDownButton.setTitle(title, for: .title)
-	}
-	
-	/// DropDownButton의 Title을 선택된 Option으로 설정합니다.
-	public func setButtonOption(_ selectedOption: String?) {
-		guard let selectedOption = selectedOption else { return }
-		dropDownButton.setTitle(selectedOption, for: .option)
-	}
-	
-	private func updateDropDownTableViewHeight() {
-		UIView.animate(withDuration: 0.3) {
-			self.dropDownTableView.snp.updateConstraints { make in
-				make.height.equalTo(self.getTableViewHeight())
-			}
-		}
-	}
-	
-	private func getTableViewHeight() -> CGFloat {
-		return min(CGFloat(dataSource.count) * 32, 192)
+	public func setConstraints(_ closure: @escaping (_ make: ConstraintMaker) -> Void) {
+		self.dropDownConstraints = closure
 	}
 }

--- a/GaeManda/Projects/Presentation/OnBoarding/Implementations/DogSetting/SecondDogSetting/SecondDogSettingViewController.swift
+++ b/GaeManda/Projects/Presentation/OnBoarding/Implementations/DogSetting/SecondDogSetting/SecondDogSettingViewController.swift
@@ -27,8 +27,10 @@ final class SecondDogSettingViewController:
 	private let navigationBar = GMDNavigationBar(title: "")
 	private let onBoardingView = OnBoardingView(willDisplayImageView: true, title: "우리 아이를 등록해주세요! (2/2)")
 	
-	private let dogBreedDropDownView = DropDownView(title: "우리 아이 종")
-	private let dogCharacterDropDownView = DropDownView(title: "우리 아이 성격")
+	private let dogBreedDropDownButton = DropDownButton(text: "우리 아이 종", mode: .title)
+	private let dogCharacterDropDownButton = DropDownButton(text: "우리 아이 성격", mode: .title)
+	private let dogBreedDropDownView = DropDownView()
+	private let dogCharacterDropDownView = DropDownView()
 	
 	private let buttonStackView: UIStackView = {
 		let stackView = UIStackView()
@@ -49,8 +51,6 @@ final class SecondDogSettingViewController:
 		super.viewDidLoad()
 		registerDropDrownViews(dogBreedDropDownView, dogCharacterDropDownView)
 		
-		dogBreedDropDownView.dataSource = viewModel.dogBreedDataSource
-		dogCharacterDropDownView.dataSource = viewModel.dogCharacterDataSource
 		setupUI()
 	}
 	
@@ -82,13 +82,14 @@ final class SecondDogSettingViewController:
 
 		setViewHierarchy()
 		setConstraints()
+		setDropDown()
 		bind()
 	}
 	
 	override func setViewHierarchy() {
 		super.setViewHierarchy()
 		contentView.addSubviews(
-			navigationBar, onBoardingView, dogBreedDropDownView, dogCharacterDropDownView, buttonStackView, confirmButton
+			navigationBar, onBoardingView, dogBreedDropDownButton, dogCharacterDropDownButton, buttonStackView, confirmButton
 		)
 		buttonStackView.addArrangedSubviews(didNeuterButton, didNotNeuterButton)
 	}
@@ -106,20 +107,32 @@ final class SecondDogSettingViewController:
 			make.trailing.equalToSuperview().offset(-32)
 		}
 		
-		dogBreedDropDownView.snp.makeConstraints { make in
+		dogBreedDropDownButton.snp.makeConstraints { make in
 			make.leading.equalToSuperview().offset(28)
 			make.top.equalTo(onBoardingView.snp.bottom).offset(56)
 			make.width.equalTo(216)
 		}
 		
-		dogCharacterDropDownView.snp.makeConstraints { make in
+		dogCharacterDropDownButton.snp.makeConstraints { make in
 			make.leading.equalToSuperview().offset(28)
-			make.top.equalTo(dogBreedDropDownView.snp.bottom).offset(48)
+			make.top.equalTo(dogBreedDropDownButton.snp.bottom).offset(48)
 			make.width.equalTo(300)
 		}
 		
+		dogBreedDropDownView.setConstraints { [weak self] make in
+			guard let self = self else { return }
+			make.leading.width.equalTo(self.dogBreedDropDownButton)
+			make.top.equalTo(self.dogBreedDropDownButton.snp.bottom)
+		}
+		
+		dogCharacterDropDownView.setConstraints { [weak self] make in
+			guard let self = self else { return }
+			make.leading.width.equalTo(self.dogCharacterDropDownButton)
+			make.top.equalTo(self.dogCharacterDropDownButton.snp.bottom)
+		}
+		
 		buttonStackView.snp.makeConstraints { make in
-			make.top.equalTo(dogCharacterDropDownView.snp.bottom).offset(52)
+			make.top.equalTo(dogCharacterDropDownButton.snp.bottom).offset(52)
 			make.leading.equalToSuperview().offset(32)
 			make.trailing.equalToSuperview().offset(-32)
 			make.height.equalTo(40)
@@ -134,10 +147,19 @@ final class SecondDogSettingViewController:
 		}
 	}
 	
+	private func setDropDown() {
+		dogBreedDropDownView.anchorView = dogBreedDropDownButton
+		dogCharacterDropDownView.anchorView = dogCharacterDropDownButton
+		
+		dogBreedDropDownView.dataSource = viewModel.dogBreedDataSource
+		dogCharacterDropDownView.dataSource = viewModel.dogCharacterDataSource
+	}
+	
 	// MARK: - UI Binding
 	override func bind() {
 		super.bind()
 		bindNavigationBar()
+		bindDropDown()
 		bindConfirmButton()
 	}
 	
@@ -145,6 +167,20 @@ final class SecondDogSettingViewController:
 		navigationBar.backButton.rx.tap
 			.bind(with: self) { owner, _ in
 				owner.listener?.didTapBackButton()
+			}
+			.disposed(by: disposeBag)
+	}
+	
+	private func bindDropDown() {
+		dogBreedDropDownView.selectedOptionRelay
+			.bind(with: self) { owner, selectedOption in
+				owner.dogBreedDropDownButton.setTitle(selectedOption, for: .option)
+			}
+			.disposed(by: disposeBag)
+		
+		dogCharacterDropDownView.selectedOptionRelay
+			.bind(with: self) { owner, selectedOption in
+				owner.dogCharacterDropDownButton.setTitle(selectedOption, for: .option)
 			}
 			.disposed(by: disposeBag)
 	}

--- a/GaeManda/Projects/Presentation/OnBoarding/Implementations/DogSetting/SecondDogSetting/SecondDogSettingViewController.swift
+++ b/GaeManda/Projects/Presentation/OnBoarding/Implementations/DogSetting/SecondDogSetting/SecondDogSettingViewController.swift
@@ -120,13 +120,13 @@ final class SecondDogSettingViewController:
 		}
 		
 		dogBreedDropDownView.setConstraints { [weak self] make in
-			guard let self = self else { return }
+			guard let self else { return }
 			make.leading.width.equalTo(self.dogBreedDropDownButton)
 			make.top.equalTo(self.dogBreedDropDownButton.snp.bottom)
 		}
 		
 		dogCharacterDropDownView.setConstraints { [weak self] make in
-			guard let self = self else { return }
+			guard let self else { return }
 			make.leading.width.equalTo(self.dogCharacterDropDownButton)
 			make.top.equalTo(self.dogCharacterDropDownButton.snp.bottom)
 		}
@@ -172,16 +172,14 @@ final class SecondDogSettingViewController:
 	}
 	
 	private func bindDropDown() {
-		dogBreedDropDownView.selectedOptionRelay
-			.bind(with: self) { owner, selectedOption in
-				owner.dogBreedDropDownButton.setTitle(selectedOption, for: .option)
-			}
+		dogBreedDropDownView.rx.selectedOption
+			.map { ($0, .option) }
+			.bind(to: dogBreedDropDownButton.rx.title)
 			.disposed(by: disposeBag)
 		
-		dogCharacterDropDownView.selectedOptionRelay
-			.bind(with: self) { owner, selectedOption in
-				owner.dogCharacterDropDownButton.setTitle(selectedOption, for: .option)
-			}
+		dogCharacterDropDownView.rx.selectedOption
+			.map { ($0, .option) }
+			.bind(to: dogCharacterDropDownButton.rx.title)
 			.disposed(by: disposeBag)
 	}
 	


### PR DESCRIPTION
## 관련 이슈

- #115 

## 작업 설명

`DropDownTableView`의 트리거가 되는 뷰를 외부에서 설정하도록 변경했습니다.

`anchorView`(트리거 되는 뷰)는 `DropDownView`의 프로퍼티를 통해 설정이 가능합니다.

```Swift 
// ViewController
private let dropDownView = DropDownView()
private let triggerView = UIView()

dropDownView.anchorView = triggerView
```

또한 `DropDownTableView`의 Constraint를 설정해주어야 합니다. 
```Swift 
// ViewController
dropDownView .setConstraints { [weak self] make in
	guard let self = self else { return }
	make.leading.width.equalTo(self.triggerView)
	make.top.equalTo(self.triggerView)
}
```

`registerDropDown`과 `dataSource`설정은 기존과 같습니다. 
